### PR TITLE
Switch to gunicorn and use older binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.9-alpine
+FROM python:3.6-alpine
 
 COPY requirements.txt /tmp/ 
 RUN pip install --requirement /tmp/requirements.txt
 
-RUN apk --update add openjdk11-jre-headless
+RUN apk --update add openjdk8-jre-base
 
 COPY ./app /app
 WORKDIR /app
 
-CMD ["waitress-serve", "--port=80", "--call", "main:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:80", "--workers", "5", "--timeout", "600", "--max-requests", "1", "--max-requests-jitter", "3", "main:app()"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pyxform-http is a Flask-based web service that uses pyxform to convert a XLSForm
 
 # Install requirements
 * Python 3
-* Java 11
+* Java 8
 
 # Run locally
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.1.2
-waitress==2.0.0
 pyxform==1.4.0
+gunicorn==20.0.4


### PR DESCRIPTION
The switch to Gunicorn is purely because it supports max-requests (killing a worker after finishing) so we don't have to deal with the leaks in pyxform/Validate. Related: https://github.com/getodk/xlsform-server/pull/22.

waitress defaults to 4 workers. Here we default to 5 based on the 2*CPUs+1 recommendation. max-requests is 1 because we really want to make sure to solve the memory leak. We add some jitter to all workers from restarting at once.

Timeout is increased to 600. We've done that on xlsform-online and it seems to work OK.

The switch to OpenJDK 1.8 is because it's smaller than OpenJDK 11. That's an assumption, I haven't actually checked. 1.8 is the minimum that JavaROSA supports.

The same "older versions are smaller" is why I've reverted to Python 3.6. It gets deprecated at the end of 2021, but it's fine for now.