### PR TITLE
Remove Docker Hub publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   push_to_registries:
-    name: Push Docker image GHCR
+    name: Push Docker image to GHCR
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -33,7 +33,7 @@ jobs:
             getodk/pyxform-http
             ghcr.io/${{ github.repository }}
       
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .


### PR DESCRIPTION
We don't think anyone uses the Docker Hub image so will focus on GHCR.