### PR TITLE
Update dockerfile python version 3.8 --> 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.11-alpine
 
 COPY requirements.txt /tmp/ 
 RUN pip install --requirement /tmp/requirements.txt


### PR DESCRIPTION
- The dependencies were all updated to the latest version in b324f7154ae1753d478001201da63e69f529a15f
- But the Dockerfile still uses `python:3.8` as it's base, which is end of life October 2024.
- All of the dependency versions support `python:3.11` EOL Oct '27 (I didn't check for `3.12`).

The container builds and the server starts up fine:

![image](https://github.com/getodk/pyxform-http/assets/78538841/42a40d82-a00d-4b81-900f-2963f4ce3447)

I also tested including pyxform-http as part of ODK Central and successfully uploaded a XLSX form for conversion to XML.