### PR TITLE
Add arm64 platform to container image build workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,16 @@ jobs:
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+            # Setup QEMU emulator to build multi-arch images
+            # https://github.com/docker/setup-qemu-action
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            # Configure Buildx for Docker build
+            # https://github.com/docker/setup-buildx-action
+            - name: Set up Buildx
+              uses: docker/setup-buildx-action@v3
+
             # Build and push Docker image with Buildx
             # https://github.com/docker/build-push-action
             - name: Build and push Docker image
@@ -45,3 +55,4 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  platforms: 'linux/amd64,linux/arm64'


### PR DESCRIPTION
Closes https://github.com/getodk/pyxform-http/issues/52

After merge, the images built via the Github workflow and published to ghcr.io should support AMD64 (default) and ARM64 also.

